### PR TITLE
set active workspace

### DIFF
--- a/internal/service/config/config.go
+++ b/internal/service/config/config.go
@@ -96,7 +96,7 @@ type ListCmd struct {
 
 type WorkspaceCmd struct {
 	Download *DownloadCmd `arg:"subcommand:download"`
-	Set *SetCmd `arg:"subcommand:set"`
+	Set      *SetCmd      `arg:"subcommand:set"`
 	Activate *ActivateCmd `arg:"subcommand:activate"`
 	List     *ListCmd     `arg:"subcommand:list"`
 	Name     string       `arg:"-n,--name" default:"default" help:"name of the workspace"`

--- a/internal/spc/workspace/handler.go
+++ b/internal/spc/workspace/handler.go
@@ -103,7 +103,7 @@ func (w *WorkspaceHandler) SetWorkspace() error {
 	workspaceDir := fmt.Sprintf("%s/.spc/workspaces/", usr.HomeDir)
 	selectedWorkspace := fmt.Sprintf("%s%s", workspaceDir, w.cfg.Args.Workspace.Set.Name)
 
-	if _,err := os.Stat(selectedWorkspace); err != nil {
+	if _, err := os.Stat(selectedWorkspace); err != nil {
 		w.log.Fatalf("could not find workspace with name: %s", w.cfg.Args.Workspace.Set.Name)
 		return nil
 	}
@@ -114,7 +114,11 @@ func (w *WorkspaceHandler) SetWorkspace() error {
 		os.Remove(activePath)
 	}
 
-	os.Symlink(selectedWorkspace, activePath)
+	err = os.Symlink(selectedWorkspace, activePath)
+	if err != nil {
+		return err
+	}
+
 	w.log.Infof("set workspace %s as active", w.cfg.Args.Workspace.Set.Name)
 	return nil
 }


### PR DESCRIPTION
implements the following command
```
spc workspace set NAME
spc workspace activate # loads vars from NAME workspace
```

this is done by creating an `active_workspace` symlink that points to the currently selected workspace
the `activate` command fails if no workspace was set before

### TODO:
- [ ] would be nice if the list command showed the currently active space